### PR TITLE
Automatically apply negation and simplify constraint specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ AGDA_EXECUTABLES_FILE := $(AGDA_DIR)/executables
 
 AGDA_HOME ?= $(AGDA_DIR)/agda
 AGDA_REPO ?= https://github.com/agda/agda
-AGDA_PR ?= 4885
+AGDA_PR ?=
 AGDA_BRANCH ?= master
 AGDA_COMMIT_HASH ?= FETCH_HEAD
 ifdef AGDA_PR
@@ -91,7 +91,7 @@ endif
 
 AGDA_STDLIB_HOME ?= $(AGDA_DIR)/standard-library
 AGDA_STDLIB_REPO ?= https://github.com/agda/agda-stdlib
-AGDA_STDLIB_PR ?= 1285
+AGDA_STDLIB_PR ?=
 AGDA_STDLIB_BRANCH ?= experimental
 AGDA_STDLIB_COMMIT_HASH ?= FETCH_HEAD
 ifdef AGDA_STDLIB_PR
@@ -102,7 +102,7 @@ endif
 
 AGDARSEC_HOME ?= $(AGDA_DIR)/agdarsec
 AGDARSEC_REPO ?= https://github.com/gallais/agdarsec
-AGDARSEC_PR ?= 17
+AGDARSEC_PR ?=
 AGDARSEC_BRANCH ?= master
 AGDARSEC_COMMIT_HASH ?= FETCH_HEAD
 ifdef AGDARSEC_PR
@@ -114,6 +114,7 @@ endif
 SCHMITTY_HOME ?= $(AGDA_DIR)/schmitty
 SCHMITTY_REPO ?= https://github.com/wenkokke/schmitty
 SCHMITTY_BRANCH ?= master
+SCHMITTY_PR ?=
 SCHMITTY_COMMIT_HASH ?= FETCH_HEAD
 ifdef SCHMITTY_PR
 SCHMITTY_LOCK := $(SCHMITTY_HOME)/pr-$(SCHMITTY_PR).lock

--- a/index.agda
+++ b/index.agda
@@ -1,17 +1,19 @@
 module index where
 
+import Moons-2-ReLU-10-ReLU-10-Softmax-2
 import AND-Gate-2-Sigmoid-1
 import Amethyst.Prelude
-import Moons-2-ReLU-10-ReLU-10-Softmax-2
-import Amethyst.PiecewiseLinear.As.Schmitty
-import Amethyst.PiecewiseLinear.As.Float
+import Identity-1-Linear-1
 import Amethyst.PiecewiseLinear.Base
-import Amethyst.Network.As.Schmitty
-import Amethyst.Network.As.Float
-import Amethyst.Network.Base
+import Amethyst.PiecewiseLinear.As.Float
+import Amethyst.PiecewiseLinear.As.Schmitty
 import Amethyst.Network
 import Amethyst.PiecewiseLinear
-import Amethyst.LinearAlgebra.As.Schmitty
-import Amethyst.LinearAlgebra.As.Float
+import Amethyst.Network.Approximation
+import Amethyst.Network.Base
+import Amethyst.Network.As.Float
+import Amethyst.Network.As.Schmitty
 import Amethyst.LinearAlgebra.Base
+import Amethyst.LinearAlgebra.As.Float
+import Amethyst.LinearAlgebra.As.Schmitty
 

--- a/models/AND-Gate-2-Sigmoid-1.agda
+++ b/models/AND-Gate-2-Sigmoid-1.agda
@@ -10,7 +10,7 @@
 module AND-Gate-2-Sigmoid-1 where
 
 open import Amethyst.Prelude
-open import Data.Float
+open import Data.Float using (Float)
 open import Function using (_$_)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 
@@ -26,21 +26,6 @@ layer = record
 model : Network Float 2 1 1
 model = layer ∷ []
 
-script : Script [] (Reals 2 ++ Reals 1) (SAT ∷ [])
-script = withReflectedNetworkAsScript model $ λ where
-  -- give names to input and output nodes
-  iv@(i₀ ∷ i₁ ∷ []) ov@(o₀ ∷ [])
-  -- give remainder of the smt-lib script
-    → assert (((i₀ == 0·0f) ∧ (i₁ == 0·0f)) ⇒ (o₀ == 0·0f))
-    ∷ assert (((i₀ == 0·0f) ∧ (i₁ == 1·0f)) ⇒ (o₀ == 0·0f))
-    ∷ assert (((i₀ == 1·0f) ∧ (i₁ == 0·0f)) ⇒ (o₀ == 0·0f))
-    ∷ assert (((i₀ == 1·0f) ∧ (i₁ == 1·0f)) ⇒ (o₀ == 1·0f))
-    ∷ check-sat
-    ∷ []
-
-_ : z3 script ≡ sat ∷ []
-_ = refl
-
 _ : evalNetwork model (0.0 ∷ 0.0 ∷ []) ≡ (0.0 ∷ [])
 _ = refl
 _ : evalNetwork model (0.0 ∷ 1.0 ∷ []) ≡ (0.0 ∷ [])
@@ -49,3 +34,16 @@ _ : evalNetwork model (1.0 ∷ 0.0 ∷ []) ≡ (0.0 ∷ [])
 _ = refl
 _ : evalNetwork model (1.0 ∷ 1.0 ∷ []) ≡ (1.0 ∷ [])
 _ = refl
+
+-- Test some valid constraints
+
+constraints : NetworkConstraints 2 1
+constraints (i₀ ∷ i₁ ∷ []) (o₀ ∷ []) =
+  (i₀ == 0·0f ∧ i₁ == 0·0f ⇒ o₀ == 0·0f) ∷
+  (i₀ == 0·0f ∧ i₁ == 1·0f ⇒ o₀ == 0·0f) ∷
+  (i₀ == 1·0f ∧ i₁ == 0·0f ⇒ o₀ == 0·0f) ∷
+  (i₀ == 1·0f ∧ i₁ == 1·0f ⇒ o₀ == 1·0f) ∷
+  []
+
+_ : z3 (query model constraints) ≡ unsat ∷ []
+_ = {!refl!}

--- a/models/AND-Gate-2-Sigmoid-1.agda
+++ b/models/AND-Gate-2-Sigmoid-1.agda
@@ -16,15 +16,26 @@ open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 
 layer : Layer Float 2 1
 layer = record
-  { weights    = [ 5.0e8 ]
-               ∷ [ 5.0e8 ]
-               ∷ []
-  ; biases     = [ -7.5e8 ]
+  { weights    = [ 5.0e1 ] ∷ [ 5.0e1 ] ∷ []
+  ; biases     = [ -7.5e1 ]
   ; activation = sigmoid
   }
 
 model : Network Float 2 1 1
 model = layer ∷ []
+
+-- Test some exact constraints
+
+exactConstraints : NetworkConstraints 2 1
+exactConstraints (i₀ ∷ i₁ ∷ []) (o₀ ∷ []) =
+  (i₀ == 0·0f ∧ i₁ == 0·0f ⇒ o₀ == 0·0f) ∷
+  (i₀ == 0·0f ∧ i₁ == 1·0f ⇒ o₀ == 0·0f) ∷
+  (i₀ == 1·0f ∧ i₁ == 0·0f ⇒ o₀ == 0·0f) ∷
+  (i₀ == 1·0f ∧ i₁ == 1·0f ⇒ o₀ == 1·0f) ∷
+  []
+
+_ : z3 (query model exactConstraints) ≡ unsat ∷ []
+_ = refl
 
 _ : evalNetwork model (0.0 ∷ 0.0 ∷ []) ≡ (0.0 ∷ [])
 _ = refl
@@ -35,15 +46,24 @@ _ = refl
 _ : evalNetwork model (1.0 ∷ 1.0 ∷ []) ≡ (1.0 ∷ [])
 _ = refl
 
--- Test some valid constraints
+-- Test some more useful constraints
 
-constraints : NetworkConstraints 2 1
-constraints (i₀ ∷ i₁ ∷ []) (o₀ ∷ []) =
-  (i₀ == 0·0f ∧ i₁ == 0·0f ⇒ o₀ == 0·0f) ∷
-  (i₀ == 0·0f ∧ i₁ == 1·0f ⇒ o₀ == 0·0f) ∷
-  (i₀ == 1·0f ∧ i₁ == 0·0f ⇒ o₀ == 0·0f) ∷
-  (i₀ == 1·0f ∧ i₁ == 1·0f ⇒ o₀ == 1·0f) ∷
+ε : ∀ {Γ} → Term Γ REAL
+ε = toReal 0.2
+
+truthy : ∀ {Γ} → Term Γ REAL → Term Γ BOOL
+truthy x = ∣ 1·0f - x ∣ ≤ ε
+
+falsey : ∀ {Γ} → Term Γ REAL → Term Γ BOOL
+falsey x = ∣ 0·0f - x ∣ ≤ ε
+
+fuzzyConstraints : NetworkConstraints 2 1
+fuzzyConstraints (i₀ ∷ i₁ ∷ []) (o₀ ∷ []) =
+  (falsey i₀ ∧ falsey i₁ ⇒ falsey o₀) ∷
+  (falsey i₀ ∧ truthy i₁ ⇒ falsey o₀) ∷
+  (truthy i₀ ∧ falsey i₁ ⇒ falsey o₀) ∷
+  (truthy i₀ ∧ truthy i₁ ⇒ truthy o₀) ∷
   []
 
-_ : z3 (query model constraints) ≡ unsat ∷ []
-_ = {!refl!}
+_ : z3 (query model fuzzyConstraints) ≡ unsat ∷ []
+_ = refl

--- a/models/Amethyst/Prelude.agda
+++ b/models/Amethyst/Prelude.agda
@@ -15,25 +15,82 @@
 --------------------------------------------------------------------------------
 module Amethyst.Prelude where
 
-open import Amethyst.Network public
-open import Amethyst.LinearAlgebra.As.Schmitty public
+open import Algebra.Core using (Op₁; Op₂)
+open import Data.Bool using (Bool)
+open import Data.Nat using (ℕ)
 open import Data.List as List public using (List; []; _∷_; _++_)
 open import Data.Vec as Vec public using (Vec; []; _∷_; [_])
+open import Data.Float using (Float)
+open import Relation.Binary.PropositionalEquality using (_≡_)
 open import SMT.Theories.Reals as Reals
+
+open import Amethyst.Network public
+open import Amethyst.LinearAlgebra.As.Schmitty public
+
 open import SMT.Backend.Z3 Reals.reflectable public using (z3)
 open import SMT.Backend.CVC4 Reals.reflectable public using (cvc4)
+
+--------------------------------------------------------------------------------
+-- Helper methods for generating constraints and queries
+
+NetworkConstraints : ℕ → ℕ → Set
+NetworkConstraints inputs outputs =
+  Vec (Real Γ) inputs →
+  Vec (Real Γ) outputs →
+  List (Term Γ BOOL)
+  where Γ = Reals inputs ++ Reals outputs
+
+processConstraints : ∀ {Γ} → List (Term Γ BOOL) → Command Γ [] []
+processConstraints constraints = assert (app₁ not (List.foldr (app₂ and) (app₀ true) constraints))
+
+query : ∀ {inputs outputs layers} (let Γ = Reals inputs ++ Reals outputs)
+  → Network Float inputs outputs layers
+  → NetworkConstraints inputs outputs
+  → Script [] Γ (SAT ∷ [])
+query n c = withReflectedNetworkAsScript n
+  (λ iv ov → processConstraints (c iv ov) ∷ check-sat ∷ [])
+
+--------------------------------------------------------------------------------
+-- Constants
 
 private
   variable
     Γ : Ctxt
 
-_⇒_ _∧_ : (a b : Term Γ BOOL) → Term Γ BOOL
-_⇒_ = app₂ implies
-_∧_ = app₂ and
-
-_==_ : (x y : Real Γ) → Term Γ BOOL
-_==_ = app₂ eq
-
 0·0f 1·0f : Real Γ
 0·0f = lit (float 0.0)
 1·0f = lit (float 1.0)
+
+--------------------------------------------------------------------------------
+-- Operators
+
+infixr 3 _⇒_
+_⇒_ : Op₂ (Term Γ BOOL)
+_⇒_ = app₂ implies
+
+infix 6 _∧_
+_∧_ : Op₂ (Term Γ BOOL)
+_∧_ = app₂ and
+
+infix 5 _∨_
+_∨_ : Op₂ (Term Γ BOOL)
+_∨_ = app₂ or
+
+infix 8 ¬_
+¬_ : Op₁ (Term Γ BOOL)
+¬_ = app₁ not
+
+infix 7 _-_
+_-_ : Op₂ (Term Γ REAL)
+_-_ = app₂ sub
+
+infix 4 _==_
+_==_ : (x y : Real Γ) → Term Γ BOOL
+_==_ = app₂ eq
+
+infix 4 _≤_
+_≤_ : (x y : Real Γ) → Term Γ BOOL
+_≤_ = app₂ leq
+
+
+

--- a/models/Amethyst/Prelude.agda
+++ b/models/Amethyst/Prelude.agda
@@ -80,15 +80,15 @@ infix 8 ¬_
 ¬_ : Op₁ (Term Γ BOOL)
 ¬_ = app₁ not
 
-infix 7 _-_
+infix 17 _-_
 _-_ : Op₂ (Term Γ REAL)
 _-_ = app₂ sub
 
-infix 4 _==_
+infix 14 _==_
 _==_ : (x y : Real Γ) → Term Γ BOOL
 _==_ = app₂ eq
 
-infix 4 _≤_
+infix 14 _≤_
 _≤_ : (x y : Real Γ) → Term Γ BOOL
 _≤_ = app₂ leq
 

--- a/models/Amethyst/Prelude.agda
+++ b/models/Amethyst/Prelude.agda
@@ -50,19 +50,19 @@ query : ∀ {inputs outputs layers} (let Γ = Reals inputs ++ Reals outputs)
 query n c = withReflectedNetworkAsScript n
   (λ iv ov → processConstraints (c iv ov) ∷ check-sat ∷ [])
 
+queryWithModel : ∀ {inputs outputs layers} (let Γ = Reals inputs ++ Reals outputs)
+  → Network Float inputs outputs layers
+  → NetworkConstraints inputs outputs
+  → Script [] Γ (MODEL Γ ∷  [])
+queryWithModel n c = withReflectedNetworkAsScript n
+  (λ iv ov → processConstraints (c iv ov) ∷ get-model ∷ [])
+
 --------------------------------------------------------------------------------
--- Constants
+-- Boolean operators
 
 private
   variable
     Γ : Ctxt
-
-0·0f 1·0f : Real Γ
-0·0f = lit (float 0.0)
-1·0f = lit (float 1.0)
-
---------------------------------------------------------------------------------
--- Operators
 
 infixr 3 _⇒_
 _⇒_ : Op₂ (Term Γ BOOL)
@@ -80,9 +80,22 @@ infix 8 ¬_
 ¬_ : Op₁ (Term Γ BOOL)
 ¬_ = app₁ not
 
+--------------------------------------------------------------------------------
+-- Float constants
+
+0·0f 1·0f : Real Γ
+0·0f = lit (float 0.0)
+1·0f = lit (float 1.0)
+
+--------------------------------------------------------------------------------
+-- Float operators and relations
+
 infix 17 _-_
 _-_ : Op₂ (Term Γ REAL)
 _-_ = app₂ sub
+
+∣_∣ : Op₁ (Term Γ REAL)
+∣ x ∣ = app₃ ite (app₂ leq x 0·0f) (app₁ neg x) x
 
 infix 14 _==_
 _==_ : (x y : Real Γ) → Term Γ BOOL
@@ -91,6 +104,3 @@ _==_ = app₂ eq
 infix 14 _≤_
 _≤_ : (x y : Real Γ) → Term Γ BOOL
 _≤_ = app₂ leq
-
-
-

--- a/models/Identity-1-Linear-1.agda
+++ b/models/Identity-1-Linear-1.agda
@@ -1,0 +1,53 @@
+--------------------------------------------------------------------------------
+-- Amethyst Models: Examples of Neural Network Verification in Agda
+--
+-- This module contains an example use of Amethyst, to verify the correctness of
+-- the identity function network.
+--------------------------------------------------------------------------------
+
+{-# OPTIONS --allow-exec #-}
+
+module Identity-1-Linear-1 where
+
+open import Amethyst.Prelude
+open import Data.Float using (Float)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+layer : Layer Float 1 1
+layer = record
+  { weights    = [ 1.0 ] ∷ []
+  ; biases     = [ 0.0 ]
+  ; activation = linear
+  }
+
+model : Network Float 1 1 1
+model = layer ∷ []
+
+_ : evalNetwork model (0.0 ∷ []) ≡ (0.0 ∷ [])
+_ = refl
+_ : evalNetwork model (1.0 ∷ []) ≡ (1.0 ∷ [])
+_ = refl
+
+
+-- Test some valid constraints
+
+constraints : NetworkConstraints 1 1
+constraints (i ∷ []) (o ∷ []) =
+  (i == 0·0f ⇒ o == 0·0f) ∷
+  (i == 1·0f ⇒ o == 1·0f) ∷
+  []
+
+_ : z3 (query model constraints) ≡ unsat ∷ []
+_ = refl
+
+
+-- Test some invalid constraints
+
+invalidConstraints : NetworkConstraints 1 1
+invalidConstraints (i ∷ []) (o ∷ []) =
+  (i == 0·0f ⇒ o == 1·0f) ∷
+  (i == 1·0f ⇒ o == 1·0f) ∷
+  []
+
+_ : z3 (query model invalidConstraints) ≡ sat ∷ []
+_ = refl

--- a/src/Amethyst/Network/Approximation.agda
+++ b/src/Amethyst/Network/Approximation.agda
@@ -1,0 +1,57 @@
+--------------------------------------------------------------------------------
+-- Amethyst: Neural Network Verification in Agda
+--
+-- This module exports some basic configuration settings for the representation
+-- of networks
+--------------------------------------------------------------------------------
+
+module Amethyst.Network.Approximation where
+
+open import Data.Nat.Base using (ℕ)
+open import Data.Float.Base
+open import Data.Unit
+open import Amethyst.PiecewiseLinear.Base
+
+module Exp where
+
+  segments = 15
+  min = -8.0
+  max = 8.0
+  lowerOutOfBounds = constant 0.0
+  upperOutOfBounds = extrapolate
+
+  approx : PiecewiseLinearFn
+  approx = linearise (e^_) min max segments lowerOutOfBounds upperOutOfBounds
+
+open Exp public using () renaming (approx to expApprox)
+
+
+-- The sigmoid function is not defined in terms of the Exp in order
+-- to avoid a loss in precision at extreme values when taking the
+-- reciprocal.
+module Sigmoid where
+
+  segments = 15
+  min = -8.0
+  max = 8.0
+  lowerOutOfBounds = constant 0.0
+  upperOutOfBounds = constant 1.0
+
+  approx : PiecewiseLinearFn
+  approx = linearise (λ x → 1.0 ÷ (1.0 + e^ - x)) min max segments lowerOutOfBounds upperOutOfBounds
+
+open Sigmoid public using () renaming (approx to sigmoidApprox)
+
+
+module HyperbolicTangent where
+
+  segments = 15
+  min = -3.0
+  max = 3.0
+  lowerOutOfBounds = constant 0.0
+  upperOutOfBounds = constant 1.0
+  
+  approx : PiecewiseLinearFn
+  approx = linearise tanh -3.0 3.0 3 lowerOutOfBounds upperOutOfBounds
+
+open HyperbolicTangent public using () renaming (approx to tanhApprox)

--- a/src/Amethyst/Network/Approximation.agda~
+++ b/src/Amethyst/Network/Approximation.agda~
@@ -1,0 +1,43 @@
+--------------------------------------------------------------------------------
+-- Amethyst: Neural Network Verification in Agda
+--
+-- This module exports some basic configuration settings for the representation
+-- of networks
+--------------------------------------------------------------------------------
+
+module Amethyst.Network.Approximation where
+
+open import Data.Nat.Base using (ℕ)
+open import Data.Float.Base
+open import Data.Unit
+open import Amethyst.PiecewiseLinear.Base
+
+module Exp where
+
+  segments = 15
+  min = -8.0
+  max = 8.0
+  lowerOutOfBounds = constant 0.0
+  upperOutOfBounds = extrapolate
+
+  approx : PiecewiseLinearFn
+  approx = linearise (e^_) min max segments lowerOutOfBounds upperOutOfBounds
+
+open Exp public using () renaming (approx to expApprox)
+
+
+-- The sigmoid function is not defined in terms of the Exp in order
+-- to avoid a loss in precision at extreme values when taking the
+-- reciprocal.
+module Sigmoid where
+
+  segments = 15
+  min = -8.0
+  max = 8.0
+  lowerOutOfBounds = constant 0.0
+  upperOutOfBounds = constant 1.0
+
+  approx : PiecewiseLinearFn
+  approx = linearise (λ x → 1.0 ÷ (1.0 + e^ - x)) min max segments lowerOutOfBounds upperOutOfBounds
+
+open Sigmoid public using () renaming (approx to sigmoidApprox)

--- a/src/Amethyst/Network/As/Float.agda
+++ b/src/Amethyst/Network/As/Float.agda
@@ -14,7 +14,10 @@
 module Amethyst.Network.As.Float where
 
 open import Amethyst.Network.Base using (Network; []; _∷_; Layer; Activation)
+open import Amethyst.Network.Approximation
 open import Amethyst.LinearAlgebra.As.Float
+open import Amethyst.PiecewiseLinear.Base
+open import Amethyst.PiecewiseLinear.As.Float
 open import Data.Bool as Bool using (if_then_else_)
 open import Data.Float as Float using (Float; _≤ᵇ_; _+_; _-_; _*_; _÷_; -_; e^_; tanh)
 open import Data.Nat as Nat using (ℕ)
@@ -32,11 +35,10 @@ private
   relu x = if x ≤ᵇ 0.0 then 0.0 else x
 
   sigmoid : Float → Float
-  sigmoid x = 1.0 ÷ (1.0 + e^ - x)
+  sigmoid x = eval sigmoidApprox x
 
   softmax : Vec Float n → Vec Float n
-  softmax xs = normalise (Vec.map e^_ xs)
-
+  softmax xs = normalise (Vec.map (eval expApprox) xs)
 
 -- * Neural networks
 

--- a/src/Amethyst/Network/As/Schmitty.agda
+++ b/src/Amethyst/Network/As/Schmitty.agda
@@ -136,7 +136,7 @@ withReflectedNetworkAsScript
   → ( (iv : Vec (Real (Reals inputs ++ Reals outputs)) inputs)
     → (ov : Vec (Real (Reals inputs ++ Reals outputs)) outputs)
     → (Script (Reals inputs ++ Reals outputs) Γ Ξ))
-    → Script [] Γ Ξ
+  → Script [] Γ Ξ
 withReflectedNetworkAsScript {inputs} {outputs} n k
   = ( Eq.subst (λ Γ → Script [] Γ []) (ʳ++-reverse (Reals inputs) (Reals outputs))
     $ declare-consts (List.reverse (Reals outputs))

--- a/src/Amethyst/Network/As/Schmitty.agda
+++ b/src/Amethyst/Network/As/Schmitty.agda
@@ -20,9 +20,11 @@ module Amethyst.Network.As.Schmitty where
 open import SMT.Theories.Reals.Base using (true)
 
 open import Amethyst.Network.Base using (Network; []; _∷_; Layer; Activation)
+open import Amethyst.Network.Approximation
 open import Amethyst.PiecewiseLinear.Base
 open import Amethyst.PiecewiseLinear.As.Schmitty
 open import Amethyst.LinearAlgebra.As.Schmitty
+
 open import Data.Fin as Fin using (Fin; zero; suc)
 open import Data.Float as Float using (Float)
 open import Data.List as List using (List; []; _∷_; _++_; _ʳ++_)
@@ -47,16 +49,16 @@ private
   relu x = app₃ ite (app₂ leq x (lit (nat 0))) (lit (nat 0)) x
 
   lexp : Real Γ → Real Γ
-  lexp = reflectExtrap (linearise Float.e^_ -4.0 4.0 15)
+  lexp = reflect expApprox
 
   lsigmoid : Real Γ → Real Γ
-  lsigmoid x = app₂ div (toReal 1.0) (app₂ add (toReal 1.0) (lexp (app₁ neg x)))
+  lsigmoid = reflect sigmoidApprox
 
   lsoftmax : Vec (Real Γ) n → Vec (Real Γ) n
   lsoftmax xs = normalise (Vec.map lexp xs)
 
   ltanh : Real Γ → Real Γ
-  ltanh = reflectExtrap (linearise Float.tanh -3.0 3.0 3)
+  ltanh = reflect tanhApprox
 
 -- |Convert activation functions to SMT terms.
 --

--- a/src/Amethyst/PiecewiseLinear/As/Float.agda
+++ b/src/Amethyst/PiecewiseLinear/As/Float.agda
@@ -4,39 +4,18 @@
 -- This module contains functions to evaluate piecewise-linear functions as
 -- functions on floating-point numbers.
 -- Piecewise-linear approximations are built over an interval `(lower, upper)`.
--- How should a piecewise-linear approximation behave outside of this interval?
--- We have three simple options:
---
---   1. We can extrapolate the first and last line segments beyond the interval
---      boundaries. This is implemented as `evalExtrap`.
---   2. We can return the minimum point, `f(lower)`, for inputs below the
---      interval, and return the maximum point, `f(upper)`, for inputs above the
---      interval. This is implemented as `evalBounded`.
---   3. We can combine (1) and (2). We start by extrapolating, following (1),
---      and allow the user to specify lower and upper bounds, where we switch to
---      returning the constant minimum and maximum, following (2). This is not
---      currently implemented.
---
--- The first option is unsound, as it may result in cases where the codomain of
--- the piecewise-linear approximation is not a subset of the codomain of the
--- approximated function. For instance, the piecewise-linear approximation of
--- the exp-function may return values <0 for a sufficiently small input.
--- However, we have found that it works well in practice. The second option is
--- sound, albeit a bit crude. The third option combines the best of (1) and (2),
--- but requires manual tweaking.
 --
 -- Exports:
 --
---   - evalExtrap
---   - evalBounded
+--   - eval
 --
 --------------------------------------------------------------------------------
 module Amethyst.PiecewiseLinear.As.Float where
 
-open import Amethyst.PiecewiseLinear.Base using (PiecewiseLinear; []; _∷_; LineSegment; head; _+[_*_]; last)
-open import Data.Bool as Bool using (Bool; true; false; if_then_else_)
+open import Amethyst.PiecewiseLinear.Base
+open import Data.Bool as Bool using (Bool; true; false; if_then_else_; not)
 open import Data.Float as Float using (Float; _+_; _*_; _≤ᵇ_)
-open import Data.Nat as Nat using (ℕ; suc; zero)
+open import Data.Nat as Nat using (ℕ; suc; zero; NonZero)
 open import Data.Vec as Vec using (Vec)
 
 private
@@ -49,34 +28,30 @@ private
 private
   -- |Return the y-value corresponding to x on the line segment ls. If x is out of
   --  bounds, extrapolate the line segment.
-  evalExtrapLineSegment : (ls : LineSegment lower upper) (x : Float) → Float
-  evalExtrapLineSegment ls x = (x * slope) + intercept
-    where
-      open LineSegment ls using (slope; intercept)
+  evalLineSegment : (ls : LineSegment lower upper) (x : Float) → Float
+  evalLineSegment ls x = (x * slope) + intercept
+    where open LineSegment ls using (slope; intercept)
 
-  -- |Return the y-value corresponding to x on the line segment ls. If x is out of
-  --  bounds, return the y-value corresponding to the x-value closest to x which is
-  --  in bounds, i.e., either lower or upper.
-  evalBoundedLineSegment : (ls : LineSegment lower upper) → Float → Float
-  evalBoundedLineSegment {lower} {upper} ls x =
-    if x ≤ᵇ lower then evalExtrapLineSegment ls lower else
-    if upper ≤ᵇ x then evalExtrapLineSegment ls upper else
-    evalExtrapLineSegment ls x
+  -- |Return the y-value corresponding to x on the piecewise-linear function.
+  --  If x is out of bounds, extrapolate the head/last line segment.
+  evalLineSegments : .{{NonZero pieces}} → (pl : LineSegments lower step pieces) → Float → Float
+  evalLineSegments {_} {lower} {step} (ls ∷ [])         x = evalLineSegment ls x
+  evalLineSegments {_} {lower} {step} (ls ∷ pl@(_ ∷ _)) x =
+    if x ≤ᵇ lower + step then evalLineSegment ls x else
+    evalLineSegments pl x
 
--- |Return the y-value corresponding to x on the piecewise-linear function.
---  If x is out of bounds, extrapolate the head/last line segment.
-evalExtrap : (pl : PiecewiseLinear lower step (suc pieces)) → Float → Float
-evalExtrap {lower} {step} (ls ∷ [])         x = evalExtrapLineSegment ls x
-evalExtrap {lower} {step} (ls ∷ pl@(_ ∷ _)) x =
-  if x ≤ᵇ lower + step then evalExtrapLineSegment ls x else
-  evalExtrap pl x
+  -- |Return the y-value corresponding to an out-of-bounds x value,
+  -- given a strategy, the last line segment, and whether it's below or above the line segment 
+  evalOutOfBoundsStrat : OutOfBoundsStrategy → LineSegment lower upper → Bool → Float → Float
+  evalOutOfBoundsStrat {_}     {_}     (constant c) _  _     _ = c
+  evalOutOfBoundsStrat {_}     {_}     extrapolate  ls _     x = evalLineSegment ls x
+  evalOutOfBoundsStrat {lower} {upper} nearestValue ls below x = evalLineSegment ls (if below then lower else upper)
 
--- |Return the y-value corresponding to x on the piecewise-linear function.
---  If x is out of bounds, return the y-value corresponding to the x-value
---  closest to x which is in bounds, i.e., either lower or upper.
-evalBounded : (pl : PiecewiseLinear lower step (suc pieces)) → Float → Float
-evalBounded {lower} {step} {pieces} pl x =
-  let upper = lower +[ step * suc pieces ]
-  in if x ≤ᵇ lower then evalExtrapLineSegment (head pl) x else
-     if upper ≤ᵇ x then evalExtrapLineSegment (last pl) x else
-     evalExtrap pl x
+eval : PiecewiseLinearFn → Float → Float
+eval f x = let module F = PiecewiseLinearFn f in
+  if x ≤ᵇ F.lower  then
+    evalOutOfBoundsStrat F.lowerOOBStrat (first F.lineSegments) true x
+  else if F.upper ≤ᵇ x then
+    evalOutOfBoundsStrat F.upperOOBStrat (last F.lineSegments) false x
+  else
+    evalLineSegments F.lineSegments x

--- a/src/Amethyst/PiecewiseLinear/As/Schmitty.agda
+++ b/src/Amethyst/PiecewiseLinear/As/Schmitty.agda
@@ -7,17 +7,16 @@
 --
 -- Exports:
 --
---  - reflectExtrap
---  - reflectBounded
+--  - reflect
 --
 --------------------------------------------------------------------------------
 module Amethyst.PiecewiseLinear.As.Schmitty where
 
 open import Amethyst.PiecewiseLinear.Base
-open import Amethyst.LinearAlgebra.As.Schmitty
+open import Amethyst.LinearAlgebra.As.Schmitty hiding (true; false)
 open import Data.Bool as Bool using (Bool; true; false; if_then_else_)
 open import Data.Float as Float using (Float; _+_; _*_; _≤ᵇ_)
-open import Data.Nat as Nat using (ℕ; suc; zero)
+open import Data.Nat as Nat using (ℕ; suc; zero; NonZero)
 open import Data.Vec as Vec using (Vec)
 open import Function using (_$_)
 
@@ -32,34 +31,29 @@ private
 private
   -- |Return the y-value corresponding to x on the line segment ls. If x is out of
   --  bounds, extrapolate the line segment.
-  reflectExtrapLineSegment : (ls : LineSegment lower upper) → Real Γ → Real Γ
-  reflectExtrapLineSegment ls x = app₂ add (app₂ mul x (toReal slope)) (toReal intercept)
-    where
-      open LineSegment ls using (slope; intercept)
+  reflectLineSegment : (ls : LineSegment lower upper) → Real Γ → Real Γ
+  reflectLineSegment ls x = app₂ add (app₂ mul x (toReal slope)) (toReal intercept)
+    where open LineSegment ls using (slope; intercept)
 
-  -- |Return the y-value corresponding to x on the line segment ls. If x is out of
-  --  bounds, return the y-value corresponding to the x-value closest to x which is
-  --  in bounds, i.e., either lower or upper.
-  reflectBoundedLineSegment : (ls : LineSegment lower upper) → Real Γ → Real Γ
-  reflectBoundedLineSegment {lower} {upper} ls x
-    = app₃ ite (app₂ leq x (toReal lower)) (reflectExtrapLineSegment ls (toReal lower))
-    $ app₃ ite (app₂ leq (toReal upper) x) (reflectExtrapLineSegment ls (toReal upper))
-    $ reflectExtrapLineSegment ls x
+  -- |Return the y-value corresponding to x on the piecewise-linear function.
+  --  If x is out of bounds, extrapolate the head/last line segment.
+  reflectLineSegments : .{{NonZero pieces}} → (pl : LineSegments lower step pieces) → Real Γ → Real Γ
+  reflectLineSegments {_} {lower} {step} (ls ∷ [])         x = reflectLineSegment ls x
+  reflectLineSegments {_} {lower} {step} (ls ∷ pl@(_ ∷ _)) x
+    = app₃ ite (app₂ leq x (app₂ add (toReal lower) (toReal step))) (reflectLineSegment ls x)
+    $ reflectLineSegments pl x
 
--- |Return the y-value corresponding to x on the piecewise-linear function.
---  If x is out of bounds, extrapolate the head/last line segment.
-reflectExtrap : (pl : PiecewiseLinear lower step (suc pieces)) → Real Γ → Real Γ
-reflectExtrap {lower} {step} (ls ∷ [])         x = reflectExtrapLineSegment ls x
-reflectExtrap {lower} {step} (ls ∷ pl@(_ ∷ _)) x
-  = app₃ ite (app₂ leq x (app₂ add (toReal lower) (toReal step))) (reflectExtrapLineSegment ls x)
-  $ reflectExtrap pl x
+  -- |Return the y-value corresponding to an out-of-bounds x value,
+  -- given a strategy, the last line segment, and whether it's below or above the line segment 
+  reflectOutOfBoundsStrat : OutOfBoundsStrategy → LineSegment lower upper → Bool → Real Γ → Real Γ
+  reflectOutOfBoundsStrat {_}     {_}     (constant c) _  _     _ = toReal c
+  reflectOutOfBoundsStrat {_}     {_}     extrapolate  ls _     x = reflectLineSegment ls x
+  reflectOutOfBoundsStrat {lower} {upper} nearestValue ls below x = reflectLineSegment ls (toReal v)
+    where v = if below then lower else upper
 
 -- |Return the y-value corresponding to x on the piecewise-linear function.
---  If x is out of bounds, return the y-value corresponding to the x-value
---  closest to x which is in bounds, i.e., either lower or upper.
-reflectBounded : (pl : PiecewiseLinear lower step (suc pieces)) → Real Γ → Real Γ
-reflectBounded {lower} {step} {pieces} pl x =
-  let upper = lower +[ step * suc pieces ]
-  in app₃ ite (app₂ leq x (toReal lower)) (reflectExtrapLineSegment (head pl) x)
-   $ app₃ ite (app₂ leq (toReal upper) x) (reflectExtrapLineSegment (last pl) x)
-   $ reflectExtrap pl x
+reflect : PiecewiseLinearFn → Real Γ → Real Γ
+reflect f x = let module F = PiecewiseLinearFn f in
+    app₃ ite (app₂ leq x (toReal F.lower)) (reflectOutOfBoundsStrat F.lowerOOBStrat (first F.lineSegments) true x)
+  $ app₃ ite (app₂ leq (toReal F.upper) x) (reflectOutOfBoundsStrat F.upperOOBStrat (first F.lineSegments) false x)
+  $ reflectLineSegments F.lineSegments x

--- a/src/Amethyst/PiecewiseLinear/Base.agda
+++ b/src/Amethyst/PiecewiseLinear/Base.agda
@@ -24,7 +24,9 @@
 -- Exports:
 --
 --   - LineSegment (slope; intercept)
---   - PiecewiseLinear ([]; _∷_)
+--   - LineSegments ([]; _∷_)
+--   - PiecewiseLinearFn ([]; _∷_)
+--   - OutOfBoundsStrategy (constant; nearest; extrapolate)
 --   - linearise
 --
 -- NOTE: The module also exports the following definitions, but these should be
@@ -39,15 +41,20 @@ module Amethyst.PiecewiseLinear.Base where
 
 open import Data.Bool as Bool using (Bool; true; false; if_then_else_)
 open import Data.Float as Float using (Float; _+_; _-_; _*_; _÷_; _≤ᵇ_)
-open import Data.Nat as Nat using (ℕ; suc; zero)
+open import Data.Nat as Nat using (ℕ; suc; zero; pred; NonZero)
 open import Data.Vec as Vec using (Vec)
 
-private
-  variable
-    pieces : ℕ
-    lower  : Float
-    step   : Float
-    upper  : Float
+-- |Repeated addition of floating-point numbers, by recursion on a natural number.
+--
+--  NOTE: The reason this is done by recusion on the natural `z`, instead of by just
+--        evaluating the floating-point expression, is that (at the time of writing)
+--        it's not possible to prove properties about floating-point arithmetic in
+--        Agda. By recursing on a natural, we can construct exactly the structure
+--        that arises from the LineSegments construction.
+--
+_+[_*_] : (x y : Float) (z : ℕ) → Float
+x +[ y * zero  ] = x
+x +[ y * suc z ] = (x + y) +[ y * z ]
 
 -- |A line segment is defined by a lower and upper bound on the x-values, a slope,
 --  and and intercept.
@@ -56,38 +63,67 @@ record LineSegment (lower upper : Float) : Set where
     slope     : Float
     intercept : Float
 
--- |A piecewise-linear function is a sequence of line segments.
-data PiecewiseLinear (lower step : Float) : (pieces : ℕ) → Set where
-  []  : PiecewiseLinear lower step 0
-  _∷_ : (ls : LineSegment lower (lower + step))
-      → (pl : PiecewiseLinear (lower + step) step pieces)
-      → PiecewiseLinear lower step (suc pieces)
+-- |A sequence of contiguous line segments.
+data LineSegments (lower step : Float) : (pieces : ℕ) → Set where
+  []  : LineSegments lower step 0
+  _∷_ : ∀ {pieces : ℕ}
+        (ls : LineSegment lower (lower + step))
+      → (pl : LineSegments (lower + step) step pieces)
+      → LineSegments lower step (suc pieces)
+
+-- |Different strategies for handling out of bounds values
+-- How should a piecewise-linear approximation behave outside of the interval?
+-- We have three simple options:
+--
+--   1. `constant`: specify a constant value
+--   2. `extrapolate`: extrapolate the last line segment beyond the interval boundaries.
+--   3. `nearest`: return the value of the nearest point within the extrapolated intervals
+--
+-- The second option is unsound, as it may result in cases where the codomain of
+-- the piecewise-linear approximation is not a subset of the codomain of the
+-- approximated function. For instance, the piecewise-linear approximation of
+-- the exp-function may return values <0 for a sufficiently small input.
+-- However, we have found that it works well in practice. The third option is
+-- sound, albeit a bit crude.
+data OutOfBoundsStrategy : Set where
+  constant      : Float → OutOfBoundsStrategy
+  extrapolate   : OutOfBoundsStrategy
+  nearestValue  : OutOfBoundsStrategy
+
+-- |A piecewise linear function
+record PiecewiseLinearFn : Set where
+  field
+    lowerOOBStrat : OutOfBoundsStrategy
+    {lower step}  : Float
+    {pieces}      : ℕ
+    .{{pieces≢0}} : NonZero pieces
+    lineSegments  : LineSegments lower step pieces
+    upperOOBStrat : OutOfBoundsStrategy
+  
+  upper : Float
+  upper = lower +[ step * suc pieces ]
+
+
+private
+  variable
+    pieces : ℕ
+    lower  : Float
+    step   : Float
+    upper  : Float
 
 -- |Return the first line segment in a piecewise-linear function.
-head : (pl : PiecewiseLinear lower step (suc pieces))
-     → LineSegment lower (lower + step)
-head (l ∷ ls) = l
-
--- |Repeated addition of floating-point numbers, by recursion on a natural number.
---
---  NOTE: The reason this is done by recusion on the natural `z`, instead of by just
---        evaluating the floating-point expression, is that (at the time of writing)
---        it's not possible to prove properties about floating-point arithmetic in
---        Agda. By recursing on a natural, we can construct exactly the structure
---        that arises from the PiecewiseLinear construction.
---
-_+[_*_] : (x y : Float) (z : ℕ) → Float
-x +[ y * zero  ] = x
-x +[ y * suc z ] = (x + y) +[ y * z ]
+first : .{{NonZero pieces}} → (pl : LineSegments lower step pieces)
+      → LineSegment lower (lower + step)
+first (l ∷ ls) = l
 
 -- |Return the last line segment in a piecewise-linear function.
-last : (pl : PiecewiseLinear lower step (suc pieces))
-     → LineSegment (lower +[ step * pieces ]) (lower +[ step * suc pieces ])
+last : .{{NonZero pieces}} → (pl : LineSegments lower step pieces)
+     → LineSegment (lower +[ step * (pred pieces) ]) (lower +[ step * pieces ])
 last (l ∷ [])         = l
 last (_ ∷ ls@(_ ∷ _)) = last ls
 
 private
-  -- |Approximate the function f between lower and upper using one line segment.
+  -- |Approximate the function f between `lower` and `lower + step` using one line segment.
   lineSegment : (f : Float → Float) (lower step : Float) → LineSegment lower (lower + step)
   lineSegment f lower step =
     let upper     = lower + step
@@ -95,18 +131,20 @@ private
         intercept = f lower - (slope * lower)
     in record { slope = slope ; intercept = intercept }
 
-  -- |Approximate the function f from lower, using pieces line segments of length step.
-  piecewiseLinear : (f : Float → Float) (lower step : Float) (pieces : ℕ) → PiecewiseLinear lower step pieces
-  piecewiseLinear f lower step zero = []
-  piecewiseLinear f lower step (suc pieces) = lineSegment f lower step ∷ piecewiseLinear f (lower + step) step pieces
+  -- |Approximate the function f from lower, using line segments of length step.
+  lineSegments : (f : Float → Float) (lower step : Float) (pieces : ℕ)
+               → LineSegments lower step pieces
+  lineSegments f lower step zero = []
+  lineSegments f lower step (suc pieces) = lineSegment f lower step ∷ lineSegments f (lower + step) step pieces
 
--- |Approximate the function f between lower and upper using pieces line segments.
-linearise : (f : Float → Float) (lower upper : Float) (pieces : ℕ)
-          → PiecewiseLinear lower ((upper - lower) ÷ Float.fromℕ pieces) pieces
-linearise f lower upper pieces = piecewiseLinear f lower ((upper - lower) ÷ Float.fromℕ pieces) pieces
+-- |Approximate the function f between lower and upper using line segments.
+linearise : (f : Float → Float) (lower upper : Float)
+            (pieces : ℕ) → .{{NonZero pieces}}
+          → (lowerOOB upperOOB : OutOfBoundsStrategy)
+          → PiecewiseLinearFn
+linearise f lower upper pieces@(suc _) lowerOOB upperOBB = record
+  { lowerOOBStrat = lowerOOB
+  ; lineSegments  = lineSegments f lower ((upper - lower) ÷ Float.fromℕ pieces) pieces
+  ; upperOOBStrat = upperOBB
+  }
 
--- -}
--- -}
--- -}
--- -}
--- -}


### PR DESCRIPTION
Sort of fixes #2. The main problem was that we weren't formulating the right query for z3. Because proving the constraints hold is equivalent to showing that there exists no assignment that violates them, we have to negate the constraints before passing them to z3 and then check for `unsat` rather than `sat`. I've added some extra boilerplate that automatically applies the negation and simplifies the process of specifying them.

Unfortunately this has exposed a new problem with the `AND-gate` example. Z3 is now incorrectly reporting SAT (with `i₀ = 0`, `i₁ = 0` and `o₀ = 2000000000000.0/63473488996304663206909.0` rather than UNSAT. 

My hypothesis is that the query is now correct but that this is a result of the linearisation of the sigmoid function. Unfortunately we currently have a disconnect between the evaluation of the network in Agda and the function we feed to z3 as the former evaluates it exactly and the later linearises it. Obviously this can be worked around if we don't test for 0.0 but merely test that it's close enough to 0.0.
